### PR TITLE
DO-5737 node version upgrade errors

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -43,7 +43,7 @@ fi
 
 # Download node from Heroku's S3 mirror of nodejs.org/dist
 status "Downloading and installing node"
-node_url="http://s3pository.heroku.com/node/v$node_version/node-v$node_version-linux-x64.tar.gz"
+node_url="https://s3pository.heroku.com/node/v$node_version/node-v$node_version-linux-x64.tar.gz"
 curl $node_url -L -s -o - | tar xzf - -C $build_dir
 
 # Move node (and npm) into ./vendor and make them executable

--- a/bin/compile
+++ b/bin/compile
@@ -44,7 +44,7 @@ fi
 # Download node from Heroku's S3 mirror of nodejs.org/dist
 status "Downloading and installing node"
 node_url="http://s3pository.heroku.com/node/v$node_version/node-v$node_version-linux-x64.tar.gz"
-curl $node_url -s -o - | tar xzf - -C $build_dir
+curl $node_url -L -s -o - | tar xzf - -C $build_dir
 
 # Move node (and npm) into ./vendor and make them executable
 mkdir -p $build_dir/vendor


### PR DESCRIPTION
https://ngpvan.atlassian.net/browse/DO-5737

Curl by default doesn't follow redirects. When it doesn't, it downloads a 0 byte file. This adds the -L argument so it will.

Search `-L, --location` for more:
https://www.man7.org/linux/man-pages/man1/curl.1.html

and the Jira item has details on how I diagnosed and what articles led me to this conclusion.

@FSQuaratiello tested against dev24 with his upgrade of node this was blocking

I've tested against develop fastaction with develop fastaction code that isn't upgraded to make sure it didn't break that deploy. Unsurprisingly, it did not.

https://build.ngpvan.com/buildConfiguration/AcceleratorDigitalServices_Fastaction_Deploy/3623901?buildTab=log&focusLine=3&linesState=500

![image](https://user-images.githubusercontent.com/3084796/136483181-7057b445-f0d6-45e1-ba3d-b4baec56d840.png)

https://dashboard.heroku.com/apps/ngpvan-fastaction-develop/settings

* [ ] Post merge I need to set develop back to the main branch for the buildpack